### PR TITLE
Fixed a problem on master

### DIFF
--- a/lib/PruebaNapakalaki.rb
+++ b/lib/PruebaNapakalaki.rb
@@ -9,7 +9,7 @@
 # PruebaNapakalaki.rb
 
 # MODIFICAR!
-require '/Users/davidvargascarrillo/Documents/NapakalakiRuby/NapakalakiRuby/lib/prize.rb'
+require './prize.rb'
 
 ################################################################################
 # TEST OF THE CRATED CLASSES


### PR DESCRIPTION
The full path of a required class was declared on the main, but it just
works using the point ( . ) to refer the actual directory (and this
will work in al computers, and not just in the mine)
